### PR TITLE
Improvements

### DIFF
--- a/smartthingstv/media_player.py
+++ b/smartthingstv/media_player.py
@@ -155,7 +155,10 @@ class smartthingstv(MediaPlayerDevice):
             else:
                 return self._channel_name + " (" + self._channel + ")"
         elif self._source.startswith("HDMI"):
-            return self._source_list[ self._source_list.index(self._source) + 1 ]
+            if self._expand_sources:
+                return self._source_list[ self._source_list.index(self._source) + 1 ]
+            else:
+                return self._source
         else:
             return self._state
 

--- a/smartthingstv/media_player.py
+++ b/smartthingstv/media_player.py
@@ -147,7 +147,17 @@ class smartthingstv(MediaPlayerDevice):
     @property
     def state(self):
         """Return the state of the device."""
-       return self._state
+        if self._state == "off":
+            return self._state
+        elif self._source in ["digitalTv", "TV"]:
+            if self._channel_name == "":
+                return self._channel
+            else:
+                return self._channel_name + " (" + self._channel + ")"
+        elif self._source.startswith("HDMI"):
+            return self._source_list[ self._source_list.index(self._source) + 1 ]
+        else:
+            return self._state
 
     @property
     def is_volume_muted(self):

--- a/smartthingstv/media_player.py
+++ b/smartthingstv/media_player.py
@@ -28,10 +28,12 @@ from homeassistant.components.media_player.const import (
     MEDIA_TYPE_APP,
 )
 from homeassistant.const import (
-    CONF_NAME, CONF_API_KEY, CONF_DEVICE_ID,
+    CONF_NAME, CONF_API_KEY, CONF_DEVICE_ID, 
 )
 import homeassistant.helpers.config_validation as cv
 from homeassistant.util import dt as dt_util
+
+CONF_EXPAND_SOURCES = "expand_sources"
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -54,7 +56,8 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
         vol.Required(CONF_API_KEY): cv.string,
         vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
-        vol.Optional(CONF_DEVICE_ID): cv.string
+        vol.Optional(CONF_DEVICE_ID): cv.string,
+        vol.Optional(CONF_EXPAND_SOURCES, default=False): cv.boolean
     }
 )
 
@@ -63,20 +66,22 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     name = config.get(CONF_NAME)
     api_key = config.get(CONF_API_KEY)
     device_id = config.get(CONF_DEVICE_ID)
-    add_entities([smartthingstv(name, api_key, device_id)])
+    expand_sources = config.get(CONF_EXPAND_SOURCES)
+    add_entities([smartthingstv(name, api_key, device_id, expand_sources)])
 
 
 
 class smartthingstv(MediaPlayerDevice):
     """Representation of a Samsung TV."""
 
-    def __init__(self, name, api_key, device_id):
+    def __init__(self, name, api_key, device_id, expand_sources):
         """Initialize the Samsung device."""
 
         # Save a reference to the imported classes
         self._name = name
         self._device_id = device_id
         self._api_key = api_key
+        self._expand_sources = expand_sources
         self._volume = 1
         self._muted = False
         self._playing = True
@@ -86,6 +91,7 @@ class smartthingstv(MediaPlayerDevice):
         self._channel = 2
         self._channel_name = ""
         self._media_title = ""
+
     def update(self):
         """Update state of device."""
         smarttv.device_update(self)
@@ -106,11 +112,18 @@ class smartthingstv(MediaPlayerDevice):
         """Volume up the media player."""
         arg = "up"
         smarttv.send_command(self, arg, cmdtype)
+
     def volume_down(self, cmdtype="stepvolume"):
         arg = ""
         smarttv.send_command(self, arg, cmdtype)
+
     def select_source(self, source, cmdtype="selectsource"):
-        smarttv.send_command(self, source, cmdtype)
+        if self._expand_sources:
+            new_source = self._source_list[ self._source_list.index(source) - 1 ]
+            smarttv.send_command(self, new_source, cmdtype)
+        else:
+            smarttv.send_command(self, source, cmdtype)
+
     @property
     def device_class(self):
         """Set the device class to TV."""
@@ -124,24 +137,21 @@ class smartthingstv(MediaPlayerDevice):
     @property
     def name(self):
         """Return the name of the device."""
-
         return self._name
 
     @property
     def media_title(self):
         """Title of current playing media."""
-
         return self._media_title
 
     @property
     def state(self):
         """Return the state of the device."""
-        return self._state
+       return self._state
 
     @property
     def is_volume_muted(self):
         """Boolean if volume is currently muted."""
-
         return self._muted
 
     @property
@@ -151,20 +161,33 @@ class smartthingstv(MediaPlayerDevice):
 
     @property
     def source(self):
+        if self._expand_sources:
+            if len(self._source) > 0:
+                return self._source_list[ self._source_list.index(self._source) + 1 ]
+            else:
+                return self._source
+        else:
+            return self._source
 
-        return self._source
     @property
     def source_list(self):
-        source_list = ['HDMI1','HDMI2','digitalTv']
-        return source_list
+        if self._expand_sources:
+            source_list = []
+            num = 0
+            for source in self._source_list:
+                num += 1
+                if (num % 2) == 0:
+                    source_list.append(source)
+            return source_list
+        else:
+            return self._source_list
+
     @property
     def channel(self):
-
         return self._channel
 
     @property
     def channel_name(self):
-
         return self._channel_name
 
     @property

--- a/smartthingstv/smartthingstv/api.py
+++ b/smartthingstv/smartthingstv/api.py
@@ -41,7 +41,7 @@ class smartthingstv:
       device_volume = int(data['main']['volume']['value']) / 100
       device_state = data['main']['switch']['value']
       device_source = data['main']['inputSource']['value']
-      device_all_sources = data['main']['supportedInputSources']['value']
+      device_all_sources = json.loads(data['main']['supportedInputSources']['value'])
       device_tv_chan = data['main']['tvChannel']['value']
       device_tv_chan_name = data['main']['tvChannelName']['value']
       device_muted = data['main']['mute']['value'] 

--- a/smartthingstv/smartthingstv/api.py
+++ b/smartthingstv/smartthingstv/api.py
@@ -38,7 +38,7 @@ class smartthingstv:
       cmdurl = requests.post(API_COMMAND,data=COMMAND_REFRESH ,headers=REQUEST_HEADERS)
       resp = requests.get(API_DEVICE_STATUS,headers=REQUEST_HEADERS)
       data = resp.json()
-      device_volume = data['main']['volume']['value']
+      device_volume = int(data['main']['volume']['value']) / 100
       device_state = data['main']['switch']['value']
       device_source = data['main']['inputSource']['value']
       device_all_sources = data['main']['supportedInputSources']['value']

--- a/smartthingstv/smartthingstv/api.py
+++ b/smartthingstv/smartthingstv/api.py
@@ -52,10 +52,7 @@ class smartthingstv:
          self._muted = True
       else:
          self._muted = False
-      if device_tv_chan_name == "":
-         self._source = device_source
-      else:
-         self._source = device_tv_chan_name
+      self._source = device_source
       self._channel = device_tv_chan
       self._channel_name = device_tv_chan_name
 


### PR DESCRIPTION
- Fixes Getting Volume Level
- Gets Input Source List from API
- Adds `expand_sources` which if set to `True` gets the input source name from the API. One of my TVs replies with `supportedInputSources: ["digitalTv", "TV", "HDMI1", "Chromecast", "HDMI2", "PC", "HDMI3", "Apple TV" ]`, enabling this removes the duplicates and only shows the real names if available.
- Device state is now dependent of scenario, instead of `on` and `off`, it now supports `off` or the channel name, or HDMI source name, etc.